### PR TITLE
Fix _mm_pause in GCC 4.8 to match code in GCC_XML/Support/GCC/4.7/xmmintrin.h

### DIFF
--- a/GCC_XML/Support/GCC/4.8/xmmintrin.h
+++ b/GCC_XML/Support/GCC/4.8/xmmintrin.h
@@ -1212,7 +1212,7 @@ _mm_sfence (void)
 extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
 _mm_pause (void)
 {
-  __builtin_ia32_pause ();
+    __asm__ __volatile__ ("rep; nop" : : );
 }
 
 /* Transpose the 4x4 matrix composed of row[0-3].  */


### PR DESCRIPTION
Trivial fix.
