### PR TITLE
Test suite failures on ppc

### DIFF
--- a/GCC_XML/Support/GCC/4.7/bits/c++config.h
+++ b/GCC_XML/Support/GCC/4.7/bits/c++config.h
@@ -1,3 +1,11 @@
+#ifdef __LONG_DOUBLE_128__
+/* Avoid using inline namespace not supported by GCC 4.2 */
+#undef __LONG_DOUBLE_128__
 #include_next <bits/c++config.h>
+#define __LONG_DOUBLE_128__ 1
+#else
+#include_next <bits/c++config.h>
+#endif
+
 /* GCC 4.2 parser does not support __int128 */
 #undef _GLIBCXX_USE_INT128

--- a/GCC_XML/Support/GCC/4.8/bits/c++config.h
+++ b/GCC_XML/Support/GCC/4.8/bits/c++config.h
@@ -1,3 +1,11 @@
+#ifdef __LONG_DOUBLE_128__
+/* Avoid using inline namespace not supported by GCC 4.2 */
+#undef __LONG_DOUBLE_128__
 #include_next <bits/c++config.h>
+#define __LONG_DOUBLE_128__ 1
+#else
+#include_next <bits/c++config.h>
+#endif
+
 /* GCC 4.2 parser does not support __int128 */
 #undef _GLIBCXX_USE_INT128


### PR DESCRIPTION
On some architectures (e.g. ppc) the #include c++config.h fails because it will use "inline namespace" which is not supported by the gccxml parser. The proposed changes to the support files works around this problem.

Without this patch running the test suite fails. The error is:

/usr/lib/gcc/ppc64-redhat-linux/4.8.2/../../../../include/c++/4.8.2/ppc64-redhat
-linux/bits/c++config.h:2019: error: expected unqualified-id before 'namespace'

The lines that cause the failure contains:

```
#if defined _GLIBCXX_LONG_DOUBLE_COMPAT && defined __LONG_DOUBLE_128__
namespace std
{
  inline namespace __gnu_cxx_ldbl128 { }
}
```

With the proposed change the test suite succeeds.
