### PR TITLE
Add case to xml_find_template_parm for VECTOR_TYPE

### DIFF
--- a/GCC/gcc/cp/xml.c
+++ b/GCC/gcc/cp/xml.c
@@ -3131,6 +3131,7 @@ xml_find_template_parm (tree t)
     case COMPONENT_REF: return xml_find_template_parm (TREE_TYPE (t));
     case POINTER_TYPE: return xml_find_template_parm (TREE_TYPE (t));
     case ARRAY_TYPE: return xml_find_template_parm (TREE_TYPE (t));
+    case VECTOR_TYPE: return xml_find_template_parm (TREE_TYPE (t));
     case OFFSET_TYPE:
       {
       return (xml_find_template_parm(TYPE_OFFSET_BASETYPE (t)) ||


### PR DESCRIPTION
I am getting the following errors when trying to parse classes that use Eigen:

xml_find_template_parm encountered unsupported type vector_type
xml_find_template_parm encountered unsupported type vector_type
xml_find_template_parm encountered unsupported type vector_type
xml_find_template_parm encountered unsupported type vector_type
xml_find_template_parm encountered unsupported type vector_type
xml_find_template_parm encountered unsupported type vector_type
xml_find_template_parm encountered unsupported type vector_type
xml_find_template_parm encountered unsupported type vector_type

Not sure this is the right fix, but it silences the messages :-)
